### PR TITLE
Add Job for creating `control-plane-queue` and Configure Components

### DIFF
--- a/charts/tembo/templates/jobs/create-cp-instance.yaml
+++ b/charts/tembo/templates/jobs/create-cp-instance.yaml
@@ -22,28 +22,46 @@ spec:
                 apiVersion: coredb.io/v1alpha1
                 kind: CoreDB
                 metadata:
-                  name: sample-coredb
+                  name: control-plane
                 spec:
-                  image: quay.io/tembo/standard-cnpg:15-120cc24
                   stop: false
-                  extensions:
-                    - name: pg_stat_statements
-                      locations:
-                        - enabled: true
-                          database: postgres
-                          schema: public
-                          version: "1.10.0"
-                    - name: pg_cron
-                      locations:
-                        - enabled: true
-                          database: postgres
-                          schema: public
-                          version: "1.6.2"
                   runtime_config:
                     - name: shared_preload_libraries
                       value: 'pg_cron,pg_stat_statements'
                     - name: pg_stat_statements.track
                       value: top
+                  trunk_installs:
+                    - name: pgmq
+                      version: 0.14.2
+                    - name: pg_partman
+                      version: 4.7.3
+                    - name: temporal_tables
+                      version: 1.2.2
+                    - name: pg_cron
+                      version: 1.6.2
+                  extensions:
+                    - name: pg_stat_statements
+                      locations:
+                        - database: postgres
+                          enabled: true
+                          version: 1.10.0
+                    - name: pgmq
+                      locations:
+                        - database: postgres
+                          enabled: true
+                          version: 0.14.2
+                    - name: temporal_tables
+                      locations:
+                        - database: postgres
+                          enabled: true
+                          version: 1.2.2
+                    - name: pg_cron
+                      locations:
+                        - enabled: true
+                          database: postgres
+                          schema: public
+                          version: 1.6.2
               EOF
+
       restartPolicy: OnFailure
 

--- a/charts/tembo/templates/jobs/create-cp-queue-instance.yaml
+++ b/charts/tembo/templates/jobs/create-cp-queue-instance.yaml
@@ -1,0 +1,76 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: create-cp-queue-database
+  namespace: {{ .Release.Namespace }}
+spec:
+  template:
+    metadata:
+      name: create-cp-queue-database
+    spec:
+      serviceAccountName: tembo-conductor
+      containers:
+        - name: kubectl
+          image: "k8s.gcr.io/hyperkube:v1.12.1"
+          imagePullPolicy: "IfNotPresent"
+          command:
+            - /bin/sh
+            - -c
+            - >
+              sleep 10;
+              kubectl create -f - <<EOF
+                apiVersion: coredb.io/v1alpha1
+                kind: CoreDB
+                metadata:
+                  name: control-plane-queue
+                spec:
+                  stop: false
+                  stack:
+                    name: MessageQueue
+                    postgres_config:
+                      - name: shared_preload_libraries
+                        value: pg_stat_statements,pg_partman_bgw
+                      - name: pg_partman_bgw.dbname
+                        value: postgres
+                      - name: pg_partman_bgw.interval
+                        value: "60"
+                      - name: pg_partman_bgw.role
+                        value: postgres
+                      - name: random_page_cost
+                        value: "1.1"
+                      - name: autovacuum_naptime
+                        value: "20s"
+                      - name: autovacuum_vacuum_cost_limit
+                        value: "10000"
+                      - name: autovacuum_vacuum_scale_factor
+                        value: "0.05"
+                      - name: autovacuum_vacuum_insert_scale_factor
+                        value: "0.05"
+                      - name: autovacuum_analyze_scale_factor
+                        value: "0.05"
+                      - name: track_io_timing
+                        value: "on"
+                      - name: checkpoint_timeout
+                        value: "10min"
+                      - name: pg_stat_statements.track
+                        value: all
+                  trunk_installs:
+                    - name: pgmq
+                      version: 0.14.2
+                    - name: pg_partman
+                      version: 4.7.3
+                  extensions:
+                    - name: pgmq
+                      locations:
+                        - database: postgres
+                          enabled: true
+                          version: 0.14.2
+                    - name: pg_partman
+                      locations:
+                        - database: postgres
+                          enabled: true
+                          version: 4.7.3
+              EOF
+
+      restartPolicy: OnFailure
+

--- a/charts/tembo/values.yaml
+++ b/charts/tembo/values.yaml
@@ -313,13 +313,13 @@ cpService:
     - name: POSTGRES_CONNECTION
       valueFrom:
         secretKeyRef:
-          key: control-plane-connection
-          name: control-plane-service
+          name: control-plane-connection
+          key: rw_uri
     - name: POSTGRES_QUEUE_CONNECTION
       valueFrom:
         secretKeyRef:
-          key: control-plane-queue-connection
-          name: control-plane-service
+          name: control-plane-queue-connection
+          key: rw_uri
 
 cpWebserver:
   logLevel: info
@@ -383,23 +383,23 @@ cpWebserver:
     - name: POSTGRES_CONNECTION
       valueFrom:
         secretKeyRef:
-          key: control-plane-connection
-          name: control-plane-webserver
+          name: control-plane-connection
+          key: rw_uri
     - name: POSTGRES_QUEUE_CONNECTION
       valueFrom:
         secretKeyRef:
-          key: control-plane-queue-connection
-          name: control-plane-webserver
-    - name: CLERK_SECRET_KEY
-      valueFrom:
-        secretKeyRef:
-          key: control-plane-clerk-token
-          name: control-plane-webserver
-    - name: CLERK_WEBHOOK_SIGNING_SECRET
-      valueFrom:
-        secretKeyRef:
-          key: control-plane-clerk-webhook-signing-secret
-          name: control-plane-webserver
+          name: control-plane-queue-connection
+          key: rw_uri
+#    - name: CLERK_SECRET_KEY
+#      valueFrom:
+#        secretKeyRef:
+#          key: control-plane-clerk-token
+#          name: control-plane-webserver
+#    - name: CLERK_WEBHOOK_SIGNING_SECRET
+#      valueFrom:
+#        secretKeyRef:
+#          key: control-plane-clerk-webhook-signing-secret
+#          name: control-plane-webserver
 #    - name: STRIPE_SECRET_KEY
 #      valueFrom:
 #        secretKeyRef:
@@ -479,13 +479,13 @@ cpReconciler:
     - name: POSTGRES_CONNECTION
       valueFrom:
         secretKeyRef:
-          name: control-plane-reconciler
-          key: control-plane-connection
+          name: control-plane-connection
+          key: rw_uri
     - name: POSTGRES_QUEUE_CONNECTION
       valueFrom:
         secretKeyRef:
-          name: control-plane-reconciler
-          key: control-plane-queue-connection
+          name: control-plane-queue-connection
+          key: rw_uri
 
 dataplaneWebserver:
   logLevel: info

--- a/charts/tembo/values.yaml
+++ b/charts/tembo/values.yaml
@@ -55,7 +55,29 @@ conductor:
   nodeSelector: {}
   tolerations: []
   affinity: {}
-  env: {}
+  env:
+    - name: PG_CONN_URL
+      valueFrom:
+        secretKeyRef:
+          name: control-plane-connection
+          key: rw_uri
+    - name: POSTGRES_QUEUE_CONNECTION
+      valueFrom:
+          secretKeyRef:
+            name: control-plane-queue-connection
+            key: rw_uri
+    - name: CONTROL_PLANE_EVENTS_QUEUE
+      value: saas_queue
+    - name: DATA_PLANE_EVENTS_QUEUE
+      value: data_plane_events
+    - name: DATA_PLANE_BASEDOMAIN
+      value: localhost
+    - name: BACKUP_ARCHIVE_BUCKET
+      value: dummy-bucket-backups
+    - name: BACKUP_ARCHIVE_BUCKET
+      value: dummy-bucket-backups
+    - name: CF_TEMPLATE_BUCKET
+      value: dummy-bucket-conductor-cf-templates
 
 tembo-operator:
   # -- The controller configuration


### PR DESCRIPTION
- Add job for creating `control-plane-queue`
- Configure control-plane components to connect to `control-plane` and `control-plane-queue` instances
- Update extensions in `control-plane` instance
- Add `conductor` environment variables