### PR TITLE
Set Default Instance Image Repository

### DIFF
--- a/charts/tembo/values.yaml
+++ b/charts/tembo/values.yaml
@@ -420,6 +420,8 @@ cpWebserver:
       value: ~
     - name: METRONOME_SECRET_KEY
       value: ~
+    - name: DEFAULT_CONTAINER_REGISTRY
+      value: quay.io/tembo
 
 cpReconciler:
   logLevel: info


### PR DESCRIPTION
Set the default instance image repository to `quay.io/tembo`. This is the repository used for newly created tembo instance images.