### PR TITLE
Move `cp-webserver` Conneciton Environment Variables to Deployment

### DIFF
--- a/charts/tembo/templates/cp-webserver/deployment.yaml
+++ b/charts/tembo/templates/cp-webserver/deployment.yaml
@@ -39,6 +39,20 @@ spec:
               containerPort: 8080
               protocol: TCP
           env:
+          - name: SERVICE_NAME
+            value: cp-webserver
+          - name: TRUNK_INSTALLS_IN_EXTENSION_LIST
+            value: 'false'
+          - name: POSTGRES_CONNECTION
+            valueFrom:
+              secretKeyRef:
+                name: control-plane-connection
+                key: rw_uri
+          - name: POSTGRES_QUEUE_CONNECTION
+            valueFrom:
+              secretKeyRef:
+                name: control-plane-queue-connection
+                key: rw_uri
           - name: RUST_LOG
             value: {{ .Values.cpWebserver.logLevel }}
           {{- if .Values.cpWebserver.env }}{{ .Values.cpWebserver.env | default list | toYaml | nindent 10 }}{{- end }}

--- a/charts/tembo/values.yaml
+++ b/charts/tembo/values.yaml
@@ -398,20 +398,6 @@ cpWebserver:
   tolerations: []
   affinity: {}
   env:
-    - name: SERVICE_NAME
-      value: cp-webserver
-    - name: TRUNK_INSTALLS_IN_EXTENSION_LIST
-      value: 'false'
-    - name: POSTGRES_CONNECTION
-      valueFrom:
-        secretKeyRef:
-          name: control-plane-connection
-          key: rw_uri
-    - name: POSTGRES_QUEUE_CONNECTION
-      valueFrom:
-        secretKeyRef:
-          name: control-plane-queue-connection
-          key: rw_uri
     - name: CLERK_SECRET_KEY
       value: ~
     - name: CLERK_WEBHOOK_SIGNING_SECRET
@@ -581,7 +567,7 @@ temboUI:
   resources:
     limits:
       cpu: 1
-      memory: 256Mi
+      memory: 512Mi
     requests:
       cpu: 100m
       memory: 128Mi


### PR DESCRIPTION
- Move `cp-webserver` connection environment variables to deployment definition
- Bump `tembo-ui` memory limit