### PR TITLE
Add `DEFAULT_CONTAINER_REGISTRY` Environment Variable to `cp-webserver` Deployment

### DIFF
--- a/charts/tembo/templates/cp-webserver/deployment.yaml
+++ b/charts/tembo/templates/cp-webserver/deployment.yaml
@@ -55,6 +55,8 @@ spec:
                 key: rw_uri
           - name: RUST_LOG
             value: {{ .Values.cpWebserver.logLevel }}
+          - name: DEFAULT_CONTAINER_REGISTRY
+            value: quay.io/tembo
           {{- if .Values.cpWebserver.env }}{{ .Values.cpWebserver.env | default list | toYaml | nindent 10 }}{{- end }}
           securityContext:
             {{- toYaml .Values.cpWebserver.securityContext | nindent 12 }}

--- a/charts/tembo/values.yaml
+++ b/charts/tembo/values.yaml
@@ -386,8 +386,6 @@ cpWebserver:
       value: ~
     - name: METRONOME_SECRET_KEY
       value: ~
-    - name: DEFAULT_CONTAINER_REGISTRY
-      value: quay.io/tembo
 
 cpReconciler:
   logLevel: info

--- a/values.yaml
+++ b/values.yaml
@@ -45,5 +45,3 @@ tembo:
         value: ~
       - name: METRONOME_SECRET_KEY
         value: ~
-      - name: DEFAULT_CONTAINER_REGISTRY
-        value: quay.io/tembo


### PR DESCRIPTION
Add `DEFAULT_CONTAINER_REGISTRY` environment variable to `cp-webserver` deployment until we have a need for overriding this value.