### PR TITLE
Drop `post-install` Hook from Label Namespace Job

### DIFF
--- a/charts/tembo/templates/jobs/label-namespace.yaml
+++ b/charts/tembo/templates/jobs/label-namespace.yaml
@@ -3,8 +3,6 @@ kind: Job
 metadata:
   name: {{ include "labelNamespaceJob.fullname" . }}
   labels: {{- include "labelNamespaceJob.labels" . | nindent 4 }}
-  annotations:
-    helm.sh/hook: post-install
 spec:
   template:
     metadata:


### PR DESCRIPTION
Drop unnecessary post install hook from label namespace job.